### PR TITLE
Real-time exchange rate section displaying Cuban Peso to  Sats

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -4205,3 +4205,207 @@ img#nostr-social {
     height: 400px; /* o la altura que necesites */
     max-width: 500px; /* opcional */
 }
+
+/* Cotización CUP/Sats Section */
+.cotizacion-section {
+    background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 50%, #1a1a1a 100%);
+    position: relative;
+    overflow: hidden;
+}
+
+.cotizacion-section::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: 
+        radial-gradient(circle at 20% 30%, rgba(244, 147, 28, 0.1) 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, rgba(28, 98, 176, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, rgba(220, 37, 43, 0.06) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.cotizacion-card {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(244, 147, 28, 0.2);
+    border-radius: 20px;
+    padding: 3rem 2rem;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(244, 147, 28, 0.2);
+    position: relative;
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.cotizacion-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(244, 147, 28, 0.2);
+}
+
+.cotizacion-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: var(--cuba-gradient-primary);
+}
+
+.cotizacion-title {
+    color: var(--cuba-blue);
+    font-weight: 800;
+    font-size: 2.5rem;
+    margin-bottom: 1rem;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.cotizacion-subtitle {
+    color: #6c757d;
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.rate-equation {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 1rem;
+    font-weight: 700;
+    flex-wrap: wrap;
+}
+
+.cup-label {
+    color: var(--cuba-blue);
+    font-size: 2.5rem;
+    font-weight: 800;
+}
+
+.equals-sign {
+    color: var(--cuba-gold);
+    font-size: 2rem;
+    font-weight: 900;
+    margin: 0 0.5rem;
+}
+
+@keyframes pulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.1); }
+}
+
+.rate-display {
+    position: relative;
+    min-height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 2rem;
+}
+
+
+#sats-amount {
+    font-size: 3.5rem;
+    font-weight: 900;
+    color: var(--cuba-gold);
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background: var(--cuba-gradient-primary);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    animation: glow 3s ease-in-out infinite alternate;
+}
+
+@keyframes glow {
+    from { text-shadow: 0 0 10px rgba(244, 147, 28, 0.3); }
+    to { text-shadow: 0 0 20px rgba(244, 147, 28, 0.6), 0 0 30px rgba(244, 147, 28, 0.4); }
+}
+
+.rate-unit {
+    font-size: 1.8rem;
+    color: var(--cuba-gold);
+    font-weight: 600;
+    text-transform: lowercase;
+    letter-spacing: 1px;
+}
+
+.rate-error {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.1rem;
+    font-weight: 500;
+}
+
+.rate-error i {
+    font-size: 1.3rem;
+}
+
+
+.spinner-border {
+    width: 3rem;
+    height: 3rem;
+    border-width: 0.3em;
+}
+
+/* Responsive Design for Cotización */
+@media (max-width: 768px) {
+    .cotizacion-card {
+        padding: 2rem 1.5rem;
+        margin: 0 1rem;
+    }
+    
+    .cotizacion-title {
+        font-size: 2rem;
+    }
+    
+    .rate-equation {
+        flex-direction: column;
+        gap: 0.5rem;
+        text-align: center;
+    }
+    
+    .cup-label {
+        font-size: 2rem;
+    }
+    
+    .equals-sign {
+        font-size: 1.5rem;
+    }
+    
+    #sats-amount {
+        font-size: 2.5rem;
+    }
+    
+    .rate-unit {
+        font-size: 1.5rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .cotizacion-card {
+        padding: 1.5rem 1rem;
+    }
+    
+    .cotizacion-title {
+        font-size: 1.8rem;
+    }
+    
+    .cup-label {
+        font-size: 1.8rem;
+    }
+    
+    .equals-sign {
+        font-size: 1.3rem;
+    }
+    
+    #sats-amount {
+        font-size: 2rem;
+    }
+    
+    .rate-unit {
+        font-size: 1.3rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 fw-bold text-uppercase">
                         <li class="nav-item"><a class="nav-link" href="#top">Inicio</a></li>
+                        <li class="nav-item"><a class="nav-link" href="#scrollspycotizacion">CUP/Sats</a></li>
                         <li class="nav-item"><a class="nav-link" href="#scrollspytools">Servicios</a></li>
                         <li class="nav-item"><a class="nav-link" href="#scrollspybuy">Compra BTC</a></li>
                         <li class="nav-item"><a class="nav-link" href="#scrollspynevents">POW</a></li>
@@ -310,6 +311,41 @@
 
         -->
 
+        <!-- Cotización CUP/Sats en vivo -->
+        <section class="py-5 cotizacion-section" id="scrollspycotizacion">
+            <div class="container-xl px-5">
+                <div class="row justify-content-center">
+                    <div class="col-lg-8 col-xl-6">
+                        <div class="cotizacion-card text-center">
+                            <div class="cotizacion-header mb-4">
+                                <h2 class="cotizacion-title text-uppercase mb-3">Cotización en Vivo</h2>
+                                <p class="cotizacion-subtitle">Precio actual del Peso Cubano en Sats</p>
+                            </div>
+                            
+                            <div class="cotizacion-display">
+                                <div class="cotizacion-main">
+                                    <div class="rate-display">
+                                        <div id="cotizacion-loader" class="spinner-border text-warning" role="status">
+                                            <span class="visually-hidden">Cargando...</span>
+                                        </div>
+                                        <div id="cotizacion-rate" class="rate-equation" style="display: none;">
+                                            <span class="cup-label">1 CUP</span>
+                                            <span class="equals-sign">=</span>
+                                            <span id="sats-amount">--</span>
+                                            <small class="rate-unit">sats</small>
+                                        </div>
+                                        <div id="cotizacion-error" class="rate-error text-danger" style="display: none;">
+                                            <i class="fas fa-exclamation-triangle"></i>
+                                            <span>Error al cargar cotización</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
 
         <!-- Servicios comunitarios -->
         <section class="py-5 services-section" id="scrollspytools">
@@ -1854,6 +1890,197 @@
 
 
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+        
+        <!-- Cotización CUP/Sats Script -->
+        <script>
+        // Cotización CUP/Sats functionality
+        class CotizacionCUPSats {
+            constructor() {
+                this.API_URL = 'https://api.yadio.io/exrates/CUP';
+                this.SATOSHI_PER_BTC = 100000000;
+                this.updateInterval = 60000; // 1 minuto
+                this.retryDelay = 5000; // 5 segundos
+                this.maxRetries = 3;
+                this.retryCount = 0;
+                
+                this.elements = {
+                    loader: document.getElementById('cotizacion-loader'),
+                    rateDisplay: document.getElementById('cotizacion-rate'),
+                    satsAmount: document.getElementById('sats-amount'),
+                    errorDisplay: document.getElementById('cotizacion-error')
+                };
+                
+                this.init();
+            }
+            
+            init() {
+                // Iniciar la primera carga
+                this.fetchRate();
+                
+                // Configurar actualizaciones automáticas
+                setInterval(() => {
+                    this.fetchRate();
+                }, this.updateInterval);
+            }
+            
+            async fetchRate() {
+                try {
+                    this.showLoader();
+                    
+                    const response = await fetch(this.API_URL, {
+                        method: 'GET',
+                        headers: {
+                            'Accept': 'application/json'
+                        }
+                    });
+                    
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    
+                    const data = await response.json();
+                    
+                    // Validar que tengamos datos de BTC
+                    // La API puede devolver data.BTC directamente o data.CUP.BTC
+                    let btcPerCup;
+                    if (data.BTC) {
+                        btcPerCup = data.BTC;
+                    } else if (data.CUP && data.CUP.BTC) {
+                        btcPerCup = data.CUP.BTC;
+                    } else {
+                        throw new Error('No se encontraron datos de BTC para CUP');
+                    }
+                    
+                    // Verificar que el valor sea un número válido y positivo
+                    if (!btcPerCup || typeof btcPerCup !== 'number' || btcPerCup <= 0) {
+                        throw new Error('Valor de BTC inválido: ' + btcPerCup);
+                    }
+                    
+                    // Calcular satoshis por CUP
+                    // La API devuelve CUP por BTC, necesitamos invertir para obtener BTC por CUP
+                    const btcPerCupCorrect = 1 / btcPerCup;
+                    const satsPerCup = btcPerCupCorrect * this.SATOSHI_PER_BTC;
+                    
+                    
+                    this.displayRate(satsPerCup, btcPerCupCorrect, data.timestamp);
+                    this.retryCount = 0; // Reset retry count on success
+                    
+                } catch (error) {
+                    console.error('Error fetching CUP/BTC rate:', error);
+                    this.handleError(error);
+                }
+            }
+            
+            displayRate(satsPerCup, btcPerCup, timestamp) {
+                // Formatear el número de satoshis con más precisión decimal
+                let formattedSats;
+                if (satsPerCup < 1) {
+                    // Para valores menores a 1, mostrar hasta 6 decimales
+                    formattedSats = satsPerCup.toFixed(6);
+                } else if (satsPerCup < 1000) {
+                    // Para valores pequeños, mostrar 4 decimales
+                    formattedSats = satsPerCup.toFixed(4);
+                } else {
+                    // Para valores grandes, usar formateo con comas y 2 decimales
+                    formattedSats = this.formatNumber(satsPerCup.toFixed(2));
+                }
+                
+                // Determinar singular o plural para 'sat/sats'
+                const roundedValue = Math.round(satsPerCup * 10000) / 10000; // Redondear a 4 decimales para comparar
+                const unit = (roundedValue === 1) ? 'sat' : 'sats';
+                
+                // Actualizar elementos DOM
+                this.elements.satsAmount.textContent = formattedSats;
+                document.querySelector('.rate-unit').textContent = unit;
+                
+                
+                // Mostrar la cotización
+                this.hideLoader();
+                this.hideError();
+                this.elements.rateDisplay.style.display = 'flex';
+                
+                // Animación de actualización
+                this.elements.satsAmount.classList.add('rate-updated');
+                setTimeout(() => {
+                    this.elements.satsAmount.classList.remove('rate-updated');
+                }, 1000);
+            }
+            
+            handleError(error) {
+                this.hideLoader();
+                this.elements.rateDisplay.style.display = 'none';
+                
+                if (this.retryCount < this.maxRetries) {
+                    this.retryCount++;
+                    console.log(`Reintentando en ${this.retryDelay/1000} segundos... (${this.retryCount}/${this.maxRetries})`);
+                    
+                    setTimeout(() => {
+                        this.fetchRate();
+                    }, this.retryDelay);
+                } else {
+                    this.showError();
+                    this.retryCount = 0;
+                }
+            }
+            
+            formatNumber(number) {
+                return number.toLocaleString('es-ES');
+            }
+            
+            formatTimestamp(timestamp) {
+                const date = new Date(timestamp);
+                return date.toLocaleTimeString('es-ES', {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                });
+            }
+            
+            showLoader() {
+                this.elements.loader.style.display = 'block';
+                this.elements.rateDisplay.style.display = 'none';
+                this.elements.errorDisplay.style.display = 'none';
+            }
+            
+            hideLoader() {
+                this.elements.loader.style.display = 'none';
+            }
+            
+            showError() {
+                this.elements.errorDisplay.style.display = 'flex';
+                this.elements.rateDisplay.style.display = 'none';
+            }
+            
+            hideError() {
+                this.elements.errorDisplay.style.display = 'none';
+            }
+        }
+        
+        // Inicializar cuando el DOM esté listo
+        document.addEventListener('DOMContentLoaded', function() {
+            const cotizacion = new CotizacionCUPSats();
+            
+            // Añadir CSS para la animación de actualización
+            const style = document.createElement('style');
+            style.textContent = `
+                .rate-updated {
+                    animation: rateUpdate 1s ease-out;
+                }
+                
+                @keyframes rateUpdate {
+                    0% { 
+                        transform: scale(1.1);
+                        filter: brightness(1.2);
+                    }
+                    100% { 
+                        transform: scale(1);
+                        filter: brightness(1);
+                    }
+                }
+            `;
+            document.head.appendChild(style);
+        });
+        </script>
         
         <script>
             // Navbar scroll effect


### PR DESCRIPTION

  Added a new real-time exchange rate section displaying Cuban Peso to
  Satoshis conversion between the hero carousel and community services.

  Key features

  - Live CUP to Sats conversion using yadio.io API
  - Auto-updates every 60 seconds with error handling
  - Clean equation display: "1 CUP = X sats" with smart singular/plural
  - Dark gradient background consistent with other sections
  - Fully responsive glassmorphic card design
  - New navbar link and scroll spy integration

  Technical implementation

  - Inverted API rate calculation (CUP per BTC to BTC per CUP)
  - Precise decimal formatting up to 6 decimal places
  - Loading states and retry mechanism
  - JavaScript class-based architecture

  Provides practical real-time information for the Cuban Bitcoin community
  to understand CUP value in Bitcoin's smallest unit.
